### PR TITLE
Add tests for core API modules

### DIFF
--- a/models/__mocks__/evento.js
+++ b/models/__mocks__/evento.js
@@ -1,0 +1,46 @@
+const eventos = [];
+
+class Evento {
+  constructor(data) {
+    Object.assign(this, data);
+    this._id = this._id || String(eventos.length + 1);
+    this.invitaciones = this.invitaciones || [];
+  }
+
+  async save() {
+    eventos.push(this);
+  }
+
+  static async find(filter) {
+    if (filter && filter.usuario) {
+      return eventos.filter(e => e.usuario === filter.usuario);
+    }
+    return eventos;
+  }
+
+  static async findOne(filter) {
+    return eventos.find(e => e._id == filter._id && e.usuario === filter.usuario) || null;
+  }
+
+  static async findById(id) {
+    return eventos.find(e => e._id == id) || null;
+  }
+
+  static async findOneAndUpdate(filter, data, options = {}) {
+    const evento = await this.findOne(filter);
+    if (!evento) return null;
+    Object.assign(evento, data);
+    return options.new ? evento : null;
+  }
+
+  static async findOneAndDelete(filter) {
+    const index = eventos.findIndex(e => e._id == filter._id && e.usuario === filter.usuario);
+    if (index === -1) return null;
+    const [deleted] = eventos.splice(index, 1);
+    return deleted;
+  }
+}
+
+Evento.__getData = () => eventos;
+
+module.exports = Evento;

--- a/models/__mocks__/invitacion.js
+++ b/models/__mocks__/invitacion.js
@@ -1,0 +1,40 @@
+const Invitacion = function(data) {
+  Object.assign(this, data);
+  this._id = this._id || String(invitaciones.length + 1);
+};
+
+const invitaciones = [];
+
+Invitacion.prototype.save = async function() {
+  invitaciones.push(this);
+};
+
+Invitacion.find = async function(filter) {
+  return invitaciones.filter(i => i.evento === filter.evento);
+};
+
+Invitacion.findByIdAndUpdate = async function(id, data, options = {}) {
+  const inv = invitaciones.find(i => i._id == id);
+  if (!inv) return null;
+  Object.assign(inv, data);
+  return options.new ? inv : null;
+};
+
+Invitacion.findOne = function(filter) {
+  const inv = invitaciones.find(i => i.token === filter.token);
+  if (!inv) return null;
+  return {
+    ...inv,
+    populate: async function(field) {
+      if (field === 'evento') {
+        const Evento = require('./evento');
+        this.evento = await Evento.findById(this.evento);
+      }
+      return this;
+    }
+  };
+};
+
+Invitacion.__getData = () => invitaciones;
+
+module.exports = Invitacion;

--- a/models/__mocks__/plan.js
+++ b/models/__mocks__/plan.js
@@ -1,0 +1,30 @@
+const planes = [];
+
+class Plan {
+  constructor(data) {
+    Object.assign(this, data);
+    this._id = this._id || String(planes.length + 1);
+  }
+
+  async save() {
+    planes.push(this);
+  }
+
+  static async create(data) {
+    const plan = new Plan(data);
+    await plan.save();
+    return plan;
+  }
+
+  static async find() {
+    return planes;
+  }
+
+  static async findById(id) {
+    return planes.find(p => p._id == id) || null;
+  }
+}
+
+Plan.__getData = () => planes;
+
+module.exports = Plan;

--- a/models/__mocks__/user.js
+++ b/models/__mocks__/user.js
@@ -1,0 +1,42 @@
+const users = [];
+
+class User {
+  constructor(data) {
+    Object.assign(this, data);
+    this._id = this._id || String(users.length + 1);
+  }
+
+  async save() {
+    users.push(this);
+  }
+
+  compararContraseña(contraseña) {
+    return Promise.resolve(this.contraseña === contraseña);
+  }
+
+  static async findOne(filter) {
+    return users.find(u => u.email === filter.email) || null;
+  }
+
+  static async find() {
+    return users;
+  }
+
+  static async findById(id) {
+    return users.find(u => u._id == id) || null;
+  }
+
+  static async findByIdAndUpdate(id, data, options = {}) {
+    const usuario = users.find(u => u._id == id);
+    if (!usuario) return null;
+    Object.assign(usuario, data);
+    return options.new ? usuario : null;
+  }
+
+  static async deleteOne(filter) {
+    const index = users.findIndex(u => u.email === filter.email);
+    if (index !== -1) users.splice(index, 1);
+  }
+}
+
+module.exports = User;

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -1,0 +1,25 @@
+jest.mock('../models/user');
+
+const request = require('supertest');
+const app = require('../app');
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  await request(app).post('/api/auth/registro').send({
+    nombre: 'Auth',
+    email: 'auth@correo.com',
+    contraseña: '123456'
+  });
+});
+
+describe('Auth API', () => {
+  it('debería iniciar sesión y devolver token', async () => {
+    const res = await request(app).post('/api/auth/login').send({
+      email: 'auth@correo.com',
+      contraseña: '123456'
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.token).toBeDefined();
+    expect(res.body.usuario.email).toBe('auth@correo.com');
+  });
+});

--- a/test/eventos.test.js
+++ b/test/eventos.test.js
@@ -1,0 +1,41 @@
+jest.mock('../models/user');
+jest.mock('../models/evento');
+
+const request = require('supertest');
+const app = require('../app');
+
+let token;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  await request(app).post('/api/auth/registro').send({
+    nombre: 'Evento',
+    email: 'evento@correo.com',
+    contraseña: '123456'
+  });
+  const resLogin = await request(app).post('/api/auth/login').send({
+    email: 'evento@correo.com',
+    contraseña: '123456'
+  });
+  token = resLogin.body.token;
+});
+
+describe('Eventos API', () => {
+  it('debería crear un evento', async () => {
+    const res = await request(app)
+      .post('/api/eventos')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ titulo: 'Mi evento' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.titulo).toBe('Mi evento');
+  });
+
+  it('debería listar los eventos del usuario', async () => {
+    const res = await request(app)
+      .get('/api/eventos')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].titulo).toBe('Mi evento');
+  });
+});

--- a/test/invitaciones.test.js
+++ b/test/invitaciones.test.js
@@ -1,0 +1,57 @@
+jest.mock('../models/user');
+jest.mock('../models/evento');
+jest.mock('../models/invitacion');
+
+const request = require('supertest');
+const app = require('../app');
+
+let token;
+let eventoId;
+let invitacion;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  await request(app).post('/api/auth/registro').send({
+    nombre: 'Invitador',
+    email: 'invitador@correo.com',
+    contraseña: '123456'
+  });
+  const resLogin = await request(app).post('/api/auth/login').send({
+    email: 'invitador@correo.com',
+    contraseña: '123456'
+  });
+  token = resLogin.body.token;
+  const resEvento = await request(app)
+    .post('/api/eventos')
+    .set('Authorization', `Bearer ${token}`)
+    .send({ titulo: 'Evento Invitacion' });
+  eventoId = resEvento.body._id;
+});
+
+describe('Invitaciones API', () => {
+  it('debería agregar una invitación a un evento', async () => {
+    const res = await request(app)
+      .post(`/api/eventos/${eventoId}/invitaciones`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ email: 'invitado@correo.com' });
+    expect(res.statusCode).toBe(201);
+    expect(res.body.email).toBe('invitado@correo.com');
+    invitacion = res.body;
+  });
+
+  it('debería listar invitaciones de un evento', async () => {
+    const res = await request(app)
+      .get(`/api/eventos/${eventoId}/invitaciones`)
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]._id).toBe(invitacion._id);
+  });
+
+  it('debería obtener la invitación por token', async () => {
+    const res = await request(app)
+      .get(`/api/invitaciones/responder/${invitacion.token}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.email).toBe('invitado@correo.com');
+  });
+});

--- a/test/planes.test.js
+++ b/test/planes.test.js
@@ -1,0 +1,45 @@
+jest.mock('../models/user');
+jest.mock('../models/plan');
+
+const request = require('supertest');
+const app = require('../app');
+const Plan = require('../models/plan');
+
+let token;
+let userId;
+let planId;
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'testsecret';
+  await request(app).post('/api/auth/registro').send({
+    nombre: 'PlanUser',
+    email: 'plan@correo.com',
+    contraseña: '123456'
+  });
+  const resLogin = await request(app).post('/api/auth/login').send({
+    email: 'plan@correo.com',
+    contraseña: '123456'
+  });
+  token = resLogin.body.token;
+  userId = resLogin.body.usuario.id;
+  const plan = await Plan.create({ nombre: 'Básico', descripcion: 'Plan básico', precio: 10 });
+  planId = plan._id;
+});
+
+describe('Planes API', () => {
+  it('debería listar los planes', async () => {
+    const res = await request(app).get('/api/planes');
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0]._id).toBe(planId);
+  });
+
+  it('debería seleccionar un plan para el usuario', async () => {
+    const res = await request(app)
+      .post(`/api/usuarios/${userId}/seleccionar-plan`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ planId });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.plan).toBe(planId);
+  });
+});

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -1,10 +1,10 @@
-const request = require('supertest');
-const app = require('../index');
-const mongoose = require('mongoose');
-const User = require('../models/user'); // <-- Agrega esta línea
+jest.mock('../models/user');
 
-beforeAll(async () => {
-  await User.deleteOne({ email: 'test@correo.com' });
+const request = require('supertest');
+const app = require('../app');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'testsecret';
 });
 
 describe('User API', () => {
@@ -18,10 +18,5 @@ describe('User API', () => {
       });
     expect(res.statusCode).toBe(201);
     expect(res.body.mensaje).toBe('Usuario registrado correctamente');
-  });
-
-  afterAll(async () => {
-    await User.deleteOne({ email: 'test@correo.com' });
-    await mongoose.connection.close();
   });
 });


### PR DESCRIPTION
## Summary
- add in-memory model mocks to allow testing without a database
- add tests for user registration, auth login, event CRUD basics, invitations, and plan selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918fd3f3588333b88a8121fc57e948