### PR TITLE
Replace 'contraseña' references with 'password'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 API REST construida con **Node.js**, **Express** y **MongoDB** para gestionar usuarios, eventos, invitaciones y planes de suscripción. El proyecto muestra buenas prácticas de desarrollo backend y está orientado a clientes o reclutadores que deseen evaluar mi trabajo.
 
 ## Características
-- Autenticación de usuarios con **JWT** y cifrado de contraseñas con **bcryptjs**.
+- Autenticación de usuarios con **JWT** y cifrado de passwords con **bcryptjs**.
 - CRUD completo de usuarios y eventos.
 - Gestión de invitaciones con confirmación mediante enlace público.
 - Selección de planes (gratuito o de pago) asociado a cada usuario.

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -4,15 +4,15 @@ const jwt = require('jsonwebtoken');
 // Registrar usuario
 exports.registrar = async (req, res) => {
   try {
-    const { nombre, email, contraseña, plan, eventos } = req.body;
-    if (!nombre || !email || !contraseña) {
+    const { nombre, email, password, plan, eventos } = req.body;
+    if (!nombre || !email || !password) {
       return res.status(400).json({ mensaje: 'Todos los campos son obligatorios' });
     }
     const usuarioExistente = await User.findOne({ email });
     if (usuarioExistente) {
       return res.status(400).json({ mensaje: 'El email ya está registrado' });
     }
-    const nuevoUsuario = new User({ nombre, email, contraseña, plan, eventos });
+    const nuevoUsuario = new User({ nombre, email, password, plan, eventos });
     await nuevoUsuario.save();
     res.status(201).json({ mensaje: 'Usuario registrado correctamente' });
   } catch (error) {
@@ -23,15 +23,15 @@ exports.registrar = async (req, res) => {
 // Login de usuario
 exports.login = async (req, res) => {
   try {
-    const { email, contraseña } = req.body;
-    if (!email || !contraseña) {
-      return res.status(400).json({ mensaje: 'Email y contraseña son obligatorios' });
+    const { email, password } = req.body;
+    if (!email || !password) {
+      return res.status(400).json({ mensaje: 'Email y password son obligatorios' });
     }
     const usuario = await User.findOne({ email });
     if (!usuario) {
       return res.status(400).json({ mensaje: 'Credenciales inválidas' });
     }
-    const esValida = await usuario.compararContraseña(contraseña);
+    const esValida = await usuario.comparePassword(password);
     if (!esValida) {
       return res.status(400).json({ mensaje: 'Credenciales inválidas' });
     }

--- a/models/__mocks__/user.js
+++ b/models/__mocks__/user.js
@@ -10,8 +10,8 @@ class User {
     users.push(this);
   }
 
-  compararContraseña(contraseña) {
-    return Promise.resolve(this.contraseña === contraseña);
+  comparePassword(password) {
+    return Promise.resolve(this.password === password);
   }
 
   static async findOne(filter) {

--- a/models/user.js
+++ b/models/user.js
@@ -13,7 +13,7 @@ const userSchema = new mongoose.Schema({
     unique: true,
     match: [/.+\@.+\..+/, 'Email inválido']
   },
-  contraseña: {
+  password: {
     type: String,
     required: true
   },
@@ -23,21 +23,21 @@ const userSchema = new mongoose.Schema({
   timestamps: true
 });
 
-// Hashear contraseña 
+// Hash password
 userSchema.pre('save', async function(next) {
-  if (!this.isModified('contraseña')) return next();
+  if (!this.isModified('password')) return next();
   try {
     const salt = await bcrypt.genSalt(10);
-    this.contraseña = await bcrypt.hash(this.contraseña, salt);
+    this.password = await bcrypt.hash(this.password, salt);
     next();
   } catch (err) {
     next(err);
   }
 });
 
-// Método para comparar contraseñas
-userSchema.methods.compararContraseña = function(contraseña) {
-  return bcrypt.compare(contraseña, this.contraseña);
+// Method to compare passwords
+userSchema.methods.comparePassword = function(password) {
+  return bcrypt.compare(password, this.password);
 };
 
 module.exports = mongoose.model('user', userSchema);

--- a/test/auth.test.js
+++ b/test/auth.test.js
@@ -8,7 +8,7 @@ beforeAll(async () => {
   await request(app).post('/api/auth/registro').send({
     nombre: 'Auth',
     email: 'auth@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
 });
 
@@ -16,7 +16,7 @@ describe('Auth API', () => {
   it('debería iniciar sesión y devolver token', async () => {
     const res = await request(app).post('/api/auth/login').send({
       email: 'auth@correo.com',
-      contraseña: '123456'
+      password: '123456'
     });
     expect(res.statusCode).toBe(200);
     expect(res.body.token).toBeDefined();

--- a/test/eventos.test.js
+++ b/test/eventos.test.js
@@ -11,11 +11,11 @@ beforeAll(async () => {
   await request(app).post('/api/auth/registro').send({
     nombre: 'Evento',
     email: 'evento@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
   const resLogin = await request(app).post('/api/auth/login').send({
     email: 'evento@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
   token = resLogin.body.token;
 });

--- a/test/invitaciones.test.js
+++ b/test/invitaciones.test.js
@@ -14,11 +14,11 @@ beforeAll(async () => {
   await request(app).post('/api/auth/registro').send({
     nombre: 'Invitador',
     email: 'invitador@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
   const resLogin = await request(app).post('/api/auth/login').send({
     email: 'invitador@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
   token = resLogin.body.token;
   const resEvento = await request(app)

--- a/test/planes.test.js
+++ b/test/planes.test.js
@@ -14,11 +14,11 @@ beforeAll(async () => {
   await request(app).post('/api/auth/registro').send({
     nombre: 'PlanUser',
     email: 'plan@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
   const resLogin = await request(app).post('/api/auth/login').send({
     email: 'plan@correo.com',
-    contraseña: '123456'
+    password: '123456'
   });
   token = resLogin.body.token;
   userId = resLogin.body.usuario.id;

--- a/test/user.test.js
+++ b/test/user.test.js
@@ -14,7 +14,7 @@ describe('User API', () => {
       .send({
         nombre: 'Test',
         email: 'test@correo.com',
-        contraseña: '123456'
+        password: '123456'
       });
     expect(res.statusCode).toBe(201);
     expect(res.body.mensaje).toBe('Usuario registrado correctamente');


### PR DESCRIPTION
## Summary
- Use `password` instead of `contraseña` throughout the codebase
- Rename user schema field and comparison method to English equivalents
- Update tests and documentation for new terminology

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895da0cd24c833391e5ce2d16ddddd4