### PR TITLE
fix: expose req.user alias and cleanup controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ API REST construida con **Node.js**, **Express** y **MongoDB** para gestionar us
 - Gestión de invitaciones con confirmación mediante enlace público.
 - Selección de planes (gratuito o de pago) asociado a cada usuario.
 - Configuración mediante variables de entorno y conexión a MongoDB.
+- Middleware de autenticación que expone el usuario autenticado en `req.user` para un acceso más sencillo.
 
 ## Tecnologías
 - Node.js

--- a/controllers/invitacionController.js
+++ b/controllers/invitacionController.js
@@ -50,7 +50,6 @@ exports.obtenerPorToken = async (req, res) => {
   }
 };
 
-// controllers/invitacionController.js
 exports.agregarInvitacionesMasivas = async (req, res) => {
   try {
     const evento = await Evento.findById(req.params.eventoId);
@@ -58,9 +57,6 @@ exports.agregarInvitacionesMasivas = async (req, res) => {
 
     const emails = (req.body.emails || []).filter(Boolean); // ['a@mail.com','b@mail.com']
     if (!emails.length) return res.status(400).json({ mensaje: 'No hay emails para procesar' });
-
-    const crypto = require('crypto');
-    const Invitacion = require('../models/invitacion');
 
     const docs = await Promise.all(
       emails.map(async (email) => {
@@ -82,7 +78,7 @@ exports.agregarInvitacionesMasivas = async (req, res) => {
 // GET /api/eventos  → del usuario autenticado
 exports.listarEventos = async (req, res) => {
   try {
-    const eventos = await Evento.find({ creador: req.user.id })
+    const eventos = await Evento.find({ creador: req.usuario.id })
       .populate({ path: 'invitaciones', select: 'email estado token createdAt' })
       .sort({ createdAt: -1 });
     res.json(eventos);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -10,6 +10,7 @@ module.exports = (req, res, next) => {
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.usuario = decoded;
+    req.user = decoded; // alias para compatibilidad con middlewares externos
     next();
   } catch (error) {
     return res.status(401).json({ mensaje: 'Token inválido o expirado' });

--- a/models/user.js
+++ b/models/user.js
@@ -41,3 +41,4 @@ userSchema.methods.comparePassword = function(password) {
 };
 
 module.exports = mongoose.model('user', userSchema);
+


### PR DESCRIPTION
## Summary
- add `req.user` alias in auth middleware for broader compatibility
- clean invitation controller duplicates and use `req.usuario`
- document authentication alias in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68995ab83cb48333822cf6f85af5cd1f