### PR TITLE
feat: add AI assistant with tools and RAG

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const userRoutes = require('./routes/user');
 const eventRoutes = require('./routes/eventos');
 const invitationRoutes = require('./routes/invitaciones');
 const planRoutes = require('./routes/planes');
+const aiRoutes = require('./routes/aiRoutes');
 
 const app = express();
 
@@ -21,6 +22,7 @@ app.use('/api/usuarios', userRoutes);
 app.use('/api/eventos', eventRoutes);
 app.use('/api', invitationRoutes);
 app.use('/api', planRoutes);
+app.use('/api/ai', aiRoutes);
 
 // 404
 app.use((req, res) => {

--- a/controllers/aiController.js
+++ b/controllers/aiController.js
@@ -1,0 +1,82 @@
+const { z } = require('zod');
+const logger = require('../services/logger');
+const { chatWithTools } = require('../services/ai/llmClient');
+const generateEmail = require('../services/ai/tools/tool.generateEmail');
+const calculateMargins = require('../services/ai/tools/tool.calculateMargins');
+const createQuoteTool = require('../services/ai/tools/tool.createQuote');
+const searchNearby = require('../services/ai/tools/tool.searchNearby');
+const summarizeRecords = require('../services/ai/tools/tool.summarizeRecords');
+const ragClient = require('../services/ai/rag/ragClient');
+
+const SYSTEM_PROMPT =
+  'Sos Nimbus Assistant. Respondé breve y accionable. Usá herramientas cuando corresponda. Nunca expongas secretos. Siempre respetá empresaId.';
+
+async function chat(req, res) {
+  const schema = z.object({
+    messages: z.array(z.object({ role: z.string(), content: z.string() })),
+    toolsAllowed: z.array(z.string()).optional()
+  });
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Datos inválidos' });
+  const { messages, toolsAllowed } = parsed.data;
+  const empresaId = req.usuario?.empresaId;
+  const role = req.usuario?.role;
+
+  const tenantSummary = `Empresa ${empresaId}`;
+  const last = messages[messages.length - 1]?.content || '';
+  let ragDocs = [];
+  try {
+    ragDocs = await ragClient.search(empresaId, last, 4);
+  } catch (e) {
+    logger.warn(e, 'Error en RAG');
+  }
+  if (tenantSummary) {
+    messages.unshift({ role: 'system', content: `Tenant: ${tenantSummary}` });
+  }
+  if (ragDocs.length) {
+    messages.push({
+      role: 'system',
+      content: `Docs relevantes:\n${ragDocs.map(d => d.text).join('\n')}`
+    });
+  }
+
+  const allowed = new Set(toolsAllowed || []);
+  const tools = [];
+  const addTool = (name, tool) => {
+    if (!toolsAllowed || allowed.has(name)) tools.push(tool);
+  };
+  addTool('generateEmail', generateEmail());
+  addTool('calculateMargins', calculateMargins());
+  if (!toolsAllowed || allowed.has('createQuote')) {
+    tools.push(createQuoteTool({ empresaId, role }));
+  }
+  addTool('searchNearby', searchNearby());
+  addTool('summarizeRecords', summarizeRecords());
+
+  try {
+    const resp = await chatWithTools({ messages, tools, systemPrompt: SYSTEM_PROMPT });
+    res.json(resp);
+  } catch (err) {
+    logger.error(err);
+    res.status(500).json({ error: 'Error en chat' });
+  }
+}
+
+async function embed(req, res) {
+  const schema = z.object({
+    docs: z.array(z.object({ id: z.string(), title: z.string().optional(), text: z.string() }))
+  });
+  const parsed = schema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: 'Datos inválidos' });
+  if (req.usuario?.role !== 'admin') return res.status(403).json({ error: 'No autorizado' });
+  const empresaId = req.usuario?.empresaId;
+  try {
+    await ragClient.addDocuments(empresaId, parsed.data.docs);
+    res.json({ ok: true });
+  } catch (err) {
+    logger.error(err);
+    res.status(500).json({ error: 'Error al generar embeddings' });
+  }
+}
+
+module.exports = { chat, embed };

--- a/middleware/rateLimitAi.js
+++ b/middleware/rateLimitAi.js
@@ -1,0 +1,18 @@
+const rateLimit = require('express-rate-limit');
+
+const { ipKeyGenerator } = rateLimit; // helper para IPv6
+
+const empresaLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 60,
+  keyGenerator: req => req.usuario?.empresaId || ipKeyGenerator(req),
+  message: 'Límite de solicitudes AI por empresa excedido'
+});
+
+const ipLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 20,
+  message: 'Límite de solicitudes AI por IP excedido'
+});
+
+module.exports = { empresaLimiter, ipLimiter };

--- a/models/embedding.js
+++ b/models/embedding.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const embeddingSchema = new mongoose.Schema(
+  {
+    empresaId: { type: String, required: true, index: true },
+    docId: { type: String, required: true },
+    title: { type: String },
+    text: { type: String, required: true },
+    embedding: { type: [Number], required: true }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Embedding', embeddingSchema);

--- a/models/product.js
+++ b/models/product.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const productSchema = new mongoose.Schema(
+  {
+    empresaId: { type: String, required: true, index: true },
+    name: { type: String, required: true },
+    price: { type: Number, required: true }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Product', productSchema);

--- a/models/quote.js
+++ b/models/quote.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const quoteSchema = new mongoose.Schema(
+  {
+    empresaId: { type: String, required: true, index: true },
+    items: [
+      {
+        productId: { type: mongoose.Schema.Types.ObjectId, ref: 'Product', required: true },
+        quantity: { type: Number, required: true, default: 1 },
+        price: { type: Number, required: true }
+      }
+    ],
+    total: { type: Number, required: true }
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model('Quote', quoteSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "axios": "^1.11.0",
         "bcryptjs": "^3.0.2",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.0.1",
         "jsonwebtoken": "^9.0.2",
-        "mongoose": "^8.17.0"
+        "mongoose": "^8.17.0",
+        "openai": "^5.12.2",
+        "pino": "^9.8.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "jest": "^30.0.5",
@@ -1609,8 +1614,27 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "30.0.5",
@@ -2145,7 +2169,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -2298,7 +2321,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -2462,7 +2484,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2624,12 +2645,39 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.0.1.tgz",
+      "integrity": "sha512-aZVCnybn7TVmxO4BtlmnvX+nuz8qHW124KKJ8dumsBsmv5ZLxE0pYu7S2nwyRBGHHCAzdmnGyrc5U/rksSPO7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-redact": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
+      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/fast-safe-stringify": {
       "version": "2.1.1",
@@ -2692,6 +2740,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
@@ -2713,7 +2781,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -2730,7 +2797,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -2740,7 +2806,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -3001,7 +3066,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3133,6 +3197,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4527,6 +4600,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -4562,6 +4644,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.12.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.12.2.tgz",
+      "integrity": "sha512-xqzHHQch5Tws5PcKR2xsZGX9xtch+JQFz5zb14dGqlshmmDAFBFEWmeIpf7wVqWV+w7Emj7jRgkNJakyKE0tYQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {
@@ -4737,6 +4840,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "9.8.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-9.8.0.tgz",
+      "integrity": "sha512-L5+rV1wL7vGAcxXP7sPpN5lrJ07Piruka6ArXr7EWBXxdVWjJshGVX8suFsiusJVcGKDGUFfbgbnKdg+VAC+0g==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "fast-redact": "^3.1.1",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
+      "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "license": "MIT"
+    },
     "node_modules/pirates": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
@@ -4788,6 +4928,22 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -4800,6 +4956,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
@@ -4849,6 +5011,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -4891,6 +5059,15 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/require-directory": {
@@ -4961,6 +5138,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5160,6 +5346,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
+      "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5188,6 +5383,15 @@
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -5492,6 +5696,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
       }
     },
     "node_modules/tmpl": {
@@ -5968,6 +6181,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,12 +13,17 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "axios": "^1.11.0",
     "bcryptjs": "^3.0.2",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.17.0"
+    "mongoose": "^8.17.0",
+    "openai": "^5.12.2",
+    "pino": "^9.8.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "jest": "^30.0.5",

--- a/routes/aiRoutes.js
+++ b/routes/aiRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const aiController = require('../controllers/aiController');
+const auth = require('../middleware/auth');
+const { empresaLimiter, ipLimiter } = require('../middleware/rateLimitAi');
+
+router.post('/chat', auth, empresaLimiter, ipLimiter, aiController.chat);
+router.post('/embed', auth, empresaLimiter, ipLimiter, aiController.embed);
+
+module.exports = router;

--- a/services/ai/llmClient.js
+++ b/services/ai/llmClient.js
@@ -1,0 +1,50 @@
+const OpenAI = require('openai');
+const logger = require('../logger');
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || 'test' });
+
+async function chatWithTools({ messages, tools = [], systemPrompt, temperature = 0.7 }) {
+  const allMessages = [{ role: 'system', content: systemPrompt }, ...messages];
+  const toolDefs = tools.map(t => ({
+    type: 'function',
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: t.schema
+    }
+  }));
+
+  const executed = [];
+  for (let i = 0; i < 5; i++) {
+    const response = await client.chat.completions.create({
+      model: process.env.LLM_MODEL || 'gpt-4o-mini',
+      messages: allMessages,
+      tools: toolDefs.length ? toolDefs : undefined,
+      temperature
+    });
+
+    const msg = response.choices[0].message;
+    if (msg.tool_calls && msg.tool_calls.length) {
+      for (const call of msg.tool_calls) {
+        const tool = tools.find(t => t.name === call.function.name);
+        if (!tool) continue;
+        try {
+          const args = JSON.parse(call.function.arguments || '{}');
+          const result = await tool.execute(args);
+          executed.push({ name: tool.name, args, result });
+          allMessages.push(msg);
+          allMessages.push({ role: 'tool', name: tool.name, content: JSON.stringify(result) });
+        } catch (err) {
+          logger.error(err, `Error executing tool ${tool.name}`);
+          allMessages.push({ role: 'tool', name: tool.name, content: 'Error ejecutando la herramienta' });
+        }
+      }
+    } else {
+      allMessages.push(msg);
+      return { messages: allMessages, toolCalls: executed, result: msg.content };
+    }
+  }
+  return { messages: allMessages, toolCalls: executed };
+}
+
+module.exports = { chatWithTools };

--- a/services/ai/rag/embedder.js
+++ b/services/ai/rag/embedder.js
@@ -1,0 +1,13 @@
+const OpenAI = require('openai');
+
+const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || 'test' });
+
+async function embed(text) {
+  const res = await client.embeddings.create({
+    model: 'text-embedding-3-small',
+    input: text
+  });
+  return res.data[0].embedding;
+}
+
+module.exports = { embed };

--- a/services/ai/rag/ragClient.js
+++ b/services/ai/rag/ragClient.js
@@ -1,0 +1,34 @@
+const Embedding = require('../../../models/embedding');
+const embedder = require('./embedder');
+
+function cosine(a, b) {
+  const dot = a.reduce((sum, v, i) => sum + v * b[i], 0);
+  const magA = Math.sqrt(a.reduce((sum, v) => sum + v * v, 0));
+  const magB = Math.sqrt(b.reduce((sum, v) => sum + v * v, 0));
+  return dot / (magA * magB);
+}
+
+async function addDocuments(empresaId, docs) {
+  for (const doc of docs) {
+    const embedding = await embedder.embed(doc.text);
+    await Embedding.findOneAndUpdate(
+      { empresaId, docId: doc.id },
+      { title: doc.title, text: doc.text, embedding },
+      { upsert: true }
+    );
+  }
+}
+
+async function search(empresaId, query, k = 4) {
+  const queryEmbedding = await embedder.embed(query);
+  const docs = await Embedding.find({ empresaId });
+  const scored = docs.map(d => ({
+    id: d.docId,
+    title: d.title,
+    text: d.text,
+    score: cosine(queryEmbedding, d.embedding)
+  }));
+  return scored.sort((a, b) => b.score - a.score).slice(0, k);
+}
+
+module.exports = { addDocuments, search };

--- a/services/ai/tools/tool.calculateMargins.js
+++ b/services/ai/tools/tool.calculateMargins.js
@@ -1,0 +1,27 @@
+module.exports = function () {
+  return {
+    name: 'calculateMargins',
+    description: 'Calcular margen de ganancia',
+    schema: {
+      type: 'object',
+      properties: {
+        cost: { type: 'number' },
+        price: { type: 'number' },
+        taxesPct: { type: 'number' },
+        feesPct: { type: 'number' }
+      },
+      required: ['cost', 'price']
+    },
+    async execute({ cost, price, taxesPct = 0, feesPct = 0 }) {
+      const taxes = price * (taxesPct / 100);
+      const fees = price * (feesPct / 100);
+      const marginAbs = price - cost - taxes - fees;
+      const marginPct = (marginAbs / price) * 100;
+      return {
+        marginAbs,
+        marginPct,
+        breakdown: { price, cost, taxes, fees }
+      };
+    }
+  };
+};

--- a/services/ai/tools/tool.createQuote.js
+++ b/services/ai/tools/tool.createQuote.js
@@ -1,0 +1,50 @@
+const Quote = require('../../../models/quote');
+const Product = require('../../../models/product');
+
+module.exports = function ({ empresaId, role }) {
+  return {
+    name: 'createQuote',
+    description: 'Crear un presupuesto y asociarlo a la empresa',
+    schema: {
+      type: 'object',
+      properties: {
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              productId: { type: 'string' },
+              quantity: { type: 'number' }
+            },
+            required: ['productId', 'quantity']
+          }
+        },
+        taxesPct: { type: 'number' },
+        feesPct: { type: 'number' }
+      },
+      required: ['items']
+    },
+    async execute({ items, taxesPct = 0, feesPct = 0 }) {
+      if (!['ventas', 'admin'].includes(role)) {
+        throw new Error('No autorizado');
+      }
+      const productIds = items.map(i => i.productId);
+      const products = await Product.find({ _id: { $in: productIds }, empresaId });
+      if (products.length !== items.length) {
+        throw new Error('Producto inválido');
+      }
+      let subtotal = 0;
+      const quoteItems = items.map(it => {
+        const product = products.find(p => p.id == it.productId);
+        const line = product.price * it.quantity;
+        subtotal += line;
+        return { productId: product._id, quantity: it.quantity, price: product.price };
+      });
+      const taxes = subtotal * (taxesPct / 100);
+      const fees = subtotal * (feesPct / 100);
+      const total = subtotal + taxes + fees;
+      const quote = await Quote.create({ empresaId, items: quoteItems, total });
+      return { presupuestoId: quote._id.toString(), total };
+    }
+  };
+};

--- a/services/ai/tools/tool.generateEmail.js
+++ b/services/ai/tools/tool.generateEmail.js
@@ -1,0 +1,25 @@
+module.exports = function () {
+  return {
+    name: 'generateEmail',
+    description: 'Redactar un correo electrónico en español',
+    schema: {
+      type: 'object',
+      properties: {
+        toName: { type: 'string' },
+        tone: { type: 'string', enum: ['formal', 'informal', 'neutral'] },
+        topic: { type: 'string' },
+        context: { type: 'string' }
+      },
+      required: ['topic']
+    },
+    async execute({ toName, tone = 'neutral', topic, context }) {
+      const saludo = toName ? `Hola ${toName},` : 'Hola,';
+      const cuerpo = context ? `${context}\n\n` : '';
+      const despedida = tone === 'formal' ? 'Saludos cordiales,' : 'Saludos,';
+      return {
+        subject: topic,
+        body: `${saludo}\n\n${cuerpo}${despedida}\nNimbus Assistant`
+      };
+    }
+  };
+};

--- a/services/ai/tools/tool.searchNearby.js
+++ b/services/ai/tools/tool.searchNearby.js
@@ -1,0 +1,37 @@
+const axios = require('axios');
+
+module.exports = function () {
+  return {
+    name: 'searchNearby',
+    description: 'Buscar lugares cercanos usando Google Places',
+    schema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string' },
+        lat: { type: 'number' },
+        lng: { type: 'number' },
+        radius: { type: 'number' }
+      },
+      required: ['query']
+    },
+    async execute({ query, lat, lng, radius = 2000 }) {
+      const params = {
+        query,
+        key: process.env.GOOGLE_PLACES_API_KEY,
+        radius
+      };
+      if (lat && lng) {
+        params.location = `${lat},${lng}`;
+      }
+      const url = 'https://maps.googleapis.com/maps/api/place/textsearch/json';
+      const resp = await axios.get(url, { params });
+      return resp.data.results.slice(0, 5).map(r => ({
+        name: r.name,
+        address: r.formatted_address,
+        rating: r.rating,
+        placeId: r.place_id,
+        mapUrl: `https://www.google.com/maps/place/?q=place_id:${r.place_id}`
+      }));
+    }
+  };
+};

--- a/services/ai/tools/tool.summarizeRecords.js
+++ b/services/ai/tools/tool.summarizeRecords.js
@@ -1,0 +1,38 @@
+const OpenAI = require('openai');
+
+module.exports = function () {
+  const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY || 'test' });
+  return {
+    name: 'summarizeRecords',
+    description: 'Genera un resumen corto de registros de clientes/ventas/productos',
+    schema: {
+      type: 'object',
+      properties: {
+        records: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              text: { type: 'string' }
+            },
+            required: ['text']
+          }
+        }
+      },
+      required: ['records']
+    },
+    async execute({ records }) {
+      const content = records.map(r => `${r.title || ''}: ${r.text}`).join('\n');
+      const res = await client.chat.completions.create({
+        model: process.env.LLM_MODEL || 'gpt-4o-mini',
+        messages: [
+          { role: 'system', content: 'Resumí brevemente en español.' },
+          { role: 'user', content }
+        ],
+        temperature: 0.2
+      });
+      return { summary: res.choices[0].message.content };
+    }
+  };
+};

--- a/services/logger.js
+++ b/services/logger.js
@@ -1,0 +1,8 @@
+const pino = require('pino');
+
+const logger = pino({
+  level: process.env.LOG_LEVEL || 'info',
+  redact: ['req.headers.authorization']
+});
+
+module.exports = logger;


### PR DESCRIPTION
## Summary
- add AI chat and embedding endpoints with tool calling and RAG context
- implement OpenAI client with multiple business tools (email, margins, quotes, search, summaries)
- enforce rate limits and roles for tenant-safe operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c3f1e48a88333bf5f52e822a90f5e